### PR TITLE
YP-28: Create endpoints for cities, localities, provinces and countries of Address

### DIFF
--- a/backend/src/main/java/com/portfolio/controller/AddressController.java
+++ b/backend/src/main/java/com/portfolio/controller/AddressController.java
@@ -1,0 +1,43 @@
+package com.portfolio.controller;
+
+import com.portfolio.service.IAddressService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/addresses")
+public class AddressController {
+
+    private final IAddressService addressService;
+
+    @Autowired
+    public AddressController(IAddressService addressService){
+        this.addressService = addressService;
+    }
+
+    @GetMapping("/cities")
+    public ResponseEntity<List<String>> getAllCities(){
+        return ResponseEntity.ok().body(addressService.getAllCities());
+    }
+
+    @GetMapping("/countries")
+    public ResponseEntity<List<String>> getAllCountries(){
+        return ResponseEntity.ok().body(addressService.getAllCountries());
+    }
+
+    @GetMapping("/localities")
+    public ResponseEntity<List<String>> getAllLocalities(){
+        return ResponseEntity.ok().body(addressService.getAllLocalities());
+    }
+
+    @GetMapping("/provinces")
+    public ResponseEntity<List<String>> getAllProvinces(){
+        return ResponseEntity.ok().body(addressService.getAllProvinces());
+    }
+
+}

--- a/backend/src/main/java/com/portfolio/service/IAddressService.java
+++ b/backend/src/main/java/com/portfolio/service/IAddressService.java
@@ -1,0 +1,15 @@
+package com.portfolio.service;
+
+import java.util.List;
+
+public interface IAddressService {
+
+    List<String> getAllCities();
+
+    List<String> getAllLocalities();
+
+    List<String> getAllProvinces();
+
+    List<String> getAllCountries();
+
+}

--- a/backend/src/main/java/com/portfolio/service/ICityService.java
+++ b/backend/src/main/java/com/portfolio/service/ICityService.java
@@ -1,0 +1,9 @@
+package com.portfolio.service;
+
+import java.util.List;
+
+public interface ICityService {
+
+    List<String> getAll();
+
+}

--- a/backend/src/main/java/com/portfolio/service/ICountryService.java
+++ b/backend/src/main/java/com/portfolio/service/ICountryService.java
@@ -1,0 +1,9 @@
+package com.portfolio.service;
+
+import java.util.List;
+
+public interface ICountryService {
+
+    List<String> getAll();
+
+}

--- a/backend/src/main/java/com/portfolio/service/ILocalityService.java
+++ b/backend/src/main/java/com/portfolio/service/ILocalityService.java
@@ -1,0 +1,9 @@
+package com.portfolio.service;
+
+import java.util.List;
+
+public interface ILocalityService {
+
+    List<String> getAll();
+
+}

--- a/backend/src/main/java/com/portfolio/service/IProvinceService.java
+++ b/backend/src/main/java/com/portfolio/service/IProvinceService.java
@@ -1,0 +1,9 @@
+package com.portfolio.service;
+
+import java.util.List;
+
+public interface IProvinceService {
+
+    List<String> getAll();
+
+}

--- a/backend/src/main/java/com/portfolio/service/impl/AddressServiceImpl.java
+++ b/backend/src/main/java/com/portfolio/service/impl/AddressServiceImpl.java
@@ -1,0 +1,48 @@
+package com.portfolio.service.impl;
+
+import com.portfolio.service.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AddressServiceImpl implements IAddressService {
+
+    private final ICityService cityService;
+    private final ICountryService countryService;
+    private final ILocalityService localityService;
+    private final IProvinceService provinceService;
+
+    @Autowired
+    public AddressServiceImpl(ICityService cityService,
+                              ICountryService countryService,
+                              ILocalityService localityService,
+                              IProvinceService provinceService){
+        this.cityService = cityService;
+        this.countryService = countryService;
+        this.localityService = localityService;
+        this.provinceService = provinceService;
+    }
+
+    @Override
+    public List<String> getAllCities() {
+        return cityService.getAll();
+    }
+
+    @Override
+    public List<String> getAllCountries() {
+        return countryService.getAll();
+    }
+
+    @Override
+    public List<String> getAllLocalities() {
+        return localityService.getAll();
+    }
+
+    @Override
+    public List<String> getAllProvinces() {
+        return provinceService.getAll();
+    }
+
+}

--- a/backend/src/main/java/com/portfolio/service/impl/CityServiceImpl.java
+++ b/backend/src/main/java/com/portfolio/service/impl/CityServiceImpl.java
@@ -1,0 +1,29 @@
+package com.portfolio.service.impl;
+
+import com.portfolio.model.entity.City;
+import com.portfolio.repository.ICityRepository;
+import com.portfolio.service.ICityService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CityServiceImpl implements ICityService {
+
+    private final ICityRepository cityRepository;
+
+    @Autowired
+    public CityServiceImpl(ICityRepository cityRepository){
+        this.cityRepository = cityRepository;
+    }
+
+    @Override
+    public List<String> getAll() {
+        return cityRepository.findAll()
+                .stream()
+                .map(City::getName)
+                .toList();
+    }
+
+}

--- a/backend/src/main/java/com/portfolio/service/impl/CountryServiceImpl.java
+++ b/backend/src/main/java/com/portfolio/service/impl/CountryServiceImpl.java
@@ -1,0 +1,29 @@
+package com.portfolio.service.impl;
+
+import com.portfolio.model.entity.Country;
+import com.portfolio.repository.ICountryRepository;
+import com.portfolio.service.ICountryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CountryServiceImpl implements ICountryService {
+
+    private final ICountryRepository countryRepository;
+
+    @Autowired
+    public CountryServiceImpl(ICountryRepository countryRepository){
+        this.countryRepository = countryRepository;
+    }
+
+    @Override
+    public List<String> getAll() {
+        return countryRepository.findAll()
+                .stream()
+                .map(Country::getName)
+                .toList();
+    }
+
+}

--- a/backend/src/main/java/com/portfolio/service/impl/LocalityServiceImpl.java
+++ b/backend/src/main/java/com/portfolio/service/impl/LocalityServiceImpl.java
@@ -1,0 +1,29 @@
+package com.portfolio.service.impl;
+
+import com.portfolio.model.entity.Locality;
+import com.portfolio.repository.ILocalityRepository;
+import com.portfolio.service.ILocalityService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class LocalityServiceImpl implements ILocalityService {
+
+    private final ILocalityRepository localityRepository;
+
+    @Autowired
+    public LocalityServiceImpl(ILocalityRepository localityRepository){
+        this.localityRepository = localityRepository;
+    }
+
+    @Override
+    public List<String> getAll() {
+        return localityRepository.findAll()
+                .stream()
+                .map(Locality::getName)
+                .toList();
+    }
+
+}

--- a/backend/src/main/java/com/portfolio/service/impl/ProvinceServiceImpl.java
+++ b/backend/src/main/java/com/portfolio/service/impl/ProvinceServiceImpl.java
@@ -1,0 +1,29 @@
+package com.portfolio.service.impl;
+
+import com.portfolio.model.entity.Province;
+import com.portfolio.repository.IProvinceRepository;
+import com.portfolio.service.IProvinceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProvinceServiceImpl implements IProvinceService {
+
+    private final IProvinceRepository provinceRepository;
+
+    @Autowired
+    public ProvinceServiceImpl(IProvinceRepository provinceRepository){
+        this.provinceRepository = provinceRepository;
+    }
+
+    @Override
+    public List<String> getAll() {
+        return provinceRepository.findAll()
+                .stream()
+                .map(Province::getName)
+                .toList();
+    }
+
+}


### PR DESCRIPTION
Summary:
- Method getAll added in ICityService and CityServiceImpl.
- Method getAll added in ILocalityService and LocalityServiceImpl.
- Method getAll added in IProvinceService and ProvinceServiceImpl.
- Method getAll added in ICountryService and CountryServiceImpl.
- Method getCities added in IAddressService and AddressServiceImpl.
- Method getLocalities added in IAddressService and AddressServiceImpl.
- Method getProvinces added in IAddressService and AddressServiceImpl.
- Method getCountries added in IAddressService and AddressServiceImpl.
- Endpoint getCities added in AddressController.
- Endpoint getLocalities added in AddressController.
- Endpoint getProvinces added in AddressController.
- Endpoint getCountries added in AddressController.